### PR TITLE
Fix bug in text parameter handling in main function and add test

### DIFF
--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -11,7 +11,7 @@ text = "Hello World!"
 source_lang = "en"
 target_lang = "pt"
 provider_api = "mymemory"
-expected_text = "H e l l o   W o r l d !"
+expected_text = "Hello World!"
 
 
 NAMESPACE = {
@@ -40,3 +40,25 @@ def test_cli_is_callled_with_correct_params(_):
             provider_api=provider_api,
         )
         translator_mock.translate.assert_called_once_with(expected_text)
+
+
+def test_main(capfd):
+    text = "Hello World!"
+    source_lang = "en"
+    target_lang = "pt"
+    provider_api = "google"
+    expected_text = "Olá Mundo!"
+
+
+    NAMESPACE = {
+        "text": text,
+        "source_lang": source_lang,
+        "target_lang": target_lang,
+        "provider_api": provider_api,
+        "notify": False
+    }
+
+    with patch('argparse.ArgumentParser.parse_args', return_value=argparse.Namespace(**NAMESPACE)):
+        main()
+        out, _ = capfd.readouterr()
+        assert out.strip() == expected_text

--- a/translator/__main__.py
+++ b/translator/__main__.py
@@ -53,7 +53,7 @@ def main():
 
     args = parser.parse_args()
 
-    text = " ".join(args.text) if args.text else clip.get()
+    text = "".join(args.text) if args.text else clip.get()
 
     translator = Translator(
         source_lang=args.source_lang,


### PR DESCRIPTION
This commit fixes a bug in the handling of the text
parameter in the main function, where it was being
joined with spaces instead of being concatenated,
causing the translation to be incorrect. It also
adds a test for the main function to ensure that
it correctly translates the text.
